### PR TITLE
support ports schema with mixed short/long wire descriptions

### DIFF
--- a/lib/expand-ports.js
+++ b/lib/expand-ports.js
@@ -2,13 +2,11 @@
 
 // http://forums.accellera.org/topic/6024-parameters-and-parameterized-port-widths-in-ipxact-1685-2009/
 
-const expandPorts = ports => {
-  if (ports.constructor !== Object) {
-    return ports;
-  }
-
-  return Object.keys(ports).reduce((res, name) => {
-    let width = ports[name];
+const expandWire = wire => {
+  if (wire['width'] && wire['direction']) {
+    return wire;
+  } else {
+    let width = wire;
     let direction = 'in';
 
     if (typeof width === 'number') {
@@ -25,12 +23,24 @@ const expandPorts = ports => {
       throw new Error(typeof width);
     }
 
+    return {
+      direction: direction,
+      width: width
+    };
+  }
+};
+
+const expandPorts = ports => {
+  if (ports.constructor !== Object) {
+    return ports.foreach((port) => {
+      port.wire = expandWire(port['wire']);
+    });
+  }
+
+  return Object.keys(ports).reduce((res, name) => {
     return res.concat({
       name: name,
-      wire: {
-        direction: direction,
-        width: width
-      }
+      wire: expandWire(ports[name])
     });
   }, []);
 };


### PR DESCRIPTION
this [duh-schema PR](https://github.com/sifive/duh-schema/pull/7) will allow `ports` definitions to mix short and long port descriptions so this PR updates `expandPorts` for the new schema